### PR TITLE
Issue/e day crit path

### DIFF
--- a/Trace/cptCriticalPath_bas.bas
+++ b/Trace/cptCriticalPath_bas.bas
@@ -1,3 +1,4 @@
+Attribute VB_Name = "cptCriticalPath_bas"
 '<cpt_version>v2.8.2</cpt_version>
 Option Explicit
 Private CritField As String 'Stores comma seperated values for each task showing which paths they are a part of

--- a/Trace/cptCriticalPath_bas.bas
+++ b/Trace/cptCriticalPath_bas.bas
@@ -1,40 +1,31 @@
-Attribute VB_Name = "cptCriticalPath_bas"
-'<cpt_version>v2.8.1</cpt_version>
+'<cpt_version>v2.8.2</cpt_version>
 Option Explicit
-
 Private CritField As String 'Stores comma seperated values for each task showing which paths they are a part of
 Private GroupField As String 'Stores a single value - used to group/sort tasks in final CP view
-
 'Custom type used to store driving path vars
 Type DrivingPaths
-
     PrimaryFloat As Double 'Stores True Float vlaue for Primary Driving Path
     FindPrimary As Boolean 'Tracks evluation progress by noting Primary Found
     SecondaryFloat As Double 'Stores True Float vlaue for Secondary Driving Path
     FindSecondary As Boolean 'Tracks evluation progress by noting Secondary Found
     TertiaryFloat As Double 'Stores True Float vlaue for Secondary Driving Path
     FindTertiary As Boolean 'Tracks evluation progress by noting Tertiar Found
-
 End Type
-
 Private tDrivingPaths As DrivingPaths 'var to store DrivingPaths type
 Private SecondaryDrivers() As String 'Array of Secondary Drivers to be analyzed
 Private SecondaryDriverCount As Integer 'Count of secondary Drivers
 Private TertiaryDrivers() As String 'Array of tertiary drivers to be analyzed
 Private TertiaryDriverCount As Integer 'Count of tertiary drivers
 Private AnalyzedTasks As Collection 'Collection of task relationships analyzied (From UID - To UID); unique to each path analysis
-
 'Custom type used to store Driving Task data
 Type DrivingTask
-
     UID As String
     tFloat As Double
-
 End Type
-
 Private DrivingTasks() As DrivingTask 'var to store DrivingTask type
-Private drivingTasksCount As Integer 'coung of DrivingTasks
-Public export_to_PPT As Boolean 'cpt ToolBar controlled var for controlling user notification of completed analysis
+Private drivingTasksCount As Integer 'count of DrivingTasks
+Public singlePath As Boolean 'cpt controlled var for limited results to a single path
+Public export_to_PPT As Boolean 'cpt controlled var for controlling user notification of completed analysis
 
 Sub DrivingPaths()
 'Primary analysis module that controls analysis
@@ -105,7 +96,7 @@ Sub DrivingPaths()
     curproj.Application.Calculation = pjManual
     curproj.Application.ScreenUpdating = False
     
-    On Error GoTo Cleanup
+    On Error GoTo CleanUp
     
     '**********************************************
     'On Error GoTo 0 '*****used for debug only*****
@@ -160,6 +151,9 @@ Sub DrivingPaths()
         evaluateTaskDependencies tdp, t, curproj, AnalyzedTasks
         
     Next tdp 'Next user selected analysis task dependency
+    
+    '<---cpt:exit here for single driving path--->
+    If singlePath Then GoTo ShowAndTell
     
     'Clear variables for re-use in evaluating secondary driver
     Set tdps = Nothing
@@ -287,10 +281,12 @@ Sub DrivingPaths()
         
     End If
     
+ShowAndTell:
+    
     'Create and Apply the "ClearPlan Driving Path" Table, View, Group, and Filter
     SetupCPView GroupField, curproj, analysisTaskUID
     
-Cleanup:
+CleanUp:
 
     'If error encountered, alert the user, otherwise notify of completion
     If err Then
@@ -343,9 +339,9 @@ Private Sub SetGroupCPFieldLookupTable(ByVal GroupField As String, ByVal curproj
     curproj.Application.CustomFieldRename FieldID:=FieldNameToFieldConstant(GroupField), newname:="CP Driving Path Group ID"
     
     'Setup Lookup Table Properties
-    curproj.Application.CustomFieldPropertiesEx FieldID:=FieldNameToFieldConstant(GroupField), attribute:=pjFieldAttributeNone
+    curproj.Application.CustomFieldPropertiesEx FieldID:=FieldNameToFieldConstant(GroupField), Attribute:=pjFieldAttributeNone
     curproj.Application.CustomOutlineCodeEditEx FieldID:=FieldNameToFieldConstant(GroupField), OnlyLookUpTableCodes:=True, OnlyLeaves:=False, LookupDefault:=False, SortOrder:=0
-    curproj.Application.CustomFieldPropertiesEx FieldID:=FieldNameToFieldConstant(GroupField), attribute:=pjFieldAttributeValueList, SummaryCalc:=pjCalcNone, GraphicalIndicators:=False, AutomaticallyRolldownToAssn:=False
+    curproj.Application.CustomFieldPropertiesEx FieldID:=FieldNameToFieldConstant(GroupField), Attribute:=pjFieldAttributeValueList, SummaryCalc:=pjCalcNone, GraphicalIndicators:=False, AutomaticallyRolldownToAssn:=False
     
     'Assign Lookup Table Values
     curproj.Application.CustomFieldValueListAdd FieldNameToFieldConstant(GroupField), "1", "Primary"
@@ -361,19 +357,19 @@ Private Sub SetupCPView(ByVal GroupField As String, ByVal curproj As Project, By
     Dim t As Task 'used to store user selected anlaysis task
     
     'Create CP Driving Path Table
-    curproj.Application.TableEditEx Name:="*ClearPlan Driving Path Table", tasktable:=True, Create:=True, ShowAddNewColumn:=True, OverwriteExisting:=True, FieldName:="ID", Width:=5, ShowInMenu:=False, DateFormat:=pjDate_mm_dd_yy, LockFirstColumn:=True, ColumnPosition:=0
+    curproj.Application.TableEditEx Name:="*ClearPlan Driving Path Table", TaskTable:=True, Create:=True, ShowAddNewColumn:=True, OverwriteExisting:=True, FieldName:="ID", Width:=5, ShowInMenu:=False, DateFormat:=pjDate_mm_dd_yy, LockFirstColumn:=True, ColumnPosition:=0
     
     'Add fields to CP Driving Path Table
-    curproj.Application.TableEditEx Name:="*ClearPlan Driving Path Table", tasktable:=True, NewFieldName:="Unique ID", Width:=10, ShowInMenu:=False, DateFormat:=pjDate_mm_dd_yy, ColumnPosition:=1, LockFirstColumn:=True
-    curproj.Application.TableEditEx Name:="*ClearPlan Driving Path Table", tasktable:=True, NewFieldName:=GroupField, Title:="Driving Path", Width:=5, ShowInMenu:=False, DateFormat:=pjDate_mm_dd_yy, ColumnPosition:=1
-    curproj.Application.TableEditEx Name:="*ClearPlan Driving Path Table", tasktable:=True, NewFieldName:="Name", Width:=45, ShowInMenu:=False, DateFormat:=pjDate_mm_dd_yy, ColumnPosition:=2
-    curproj.Application.TableEditEx Name:="*ClearPlan Driving Path Table", tasktable:=True, NewFieldName:="Duration", Width:=10, ShowInMenu:=False, DateFormat:=pjDate_mm_dd_yy, ColumnPosition:=3
-    curproj.Application.TableEditEx Name:="*ClearPlan Driving Path Table", tasktable:=True, NewFieldName:="Start", Width:=15, ShowInMenu:=False, DateFormat:=pjDate_mm_dd_yy, ColumnPosition:=4
-    curproj.Application.TableEditEx Name:="*ClearPlan Driving Path Table", tasktable:=True, NewFieldName:="Finish", Width:=15, ShowInMenu:=False, DateFormat:=pjDate_mm_dd_yy, ColumnPosition:=5
-    curproj.Application.TableEditEx Name:="*ClearPlan Driving Path Table", tasktable:=True, NewFieldName:="Total Slack", Width:=10, ShowInMenu:=False, DateFormat:=pjDate_mm_dd_yy, ColumnPosition:=6
+    curproj.Application.TableEditEx Name:="*ClearPlan Driving Path Table", TaskTable:=True, NewFieldName:="Unique ID", Width:=10, ShowInMenu:=False, DateFormat:=pjDate_mm_dd_yy, ColumnPosition:=1, LockFirstColumn:=True
+    curproj.Application.TableEditEx Name:="*ClearPlan Driving Path Table", TaskTable:=True, NewFieldName:=GroupField, Title:="Driving Path", Width:=5, ShowInMenu:=False, DateFormat:=pjDate_mm_dd_yy, ColumnPosition:=1
+    curproj.Application.TableEditEx Name:="*ClearPlan Driving Path Table", TaskTable:=True, NewFieldName:="Name", Width:=45, ShowInMenu:=False, DateFormat:=pjDate_mm_dd_yy, ColumnPosition:=2
+    curproj.Application.TableEditEx Name:="*ClearPlan Driving Path Table", TaskTable:=True, NewFieldName:="Duration", Width:=10, ShowInMenu:=False, DateFormat:=pjDate_mm_dd_yy, ColumnPosition:=3
+    curproj.Application.TableEditEx Name:="*ClearPlan Driving Path Table", TaskTable:=True, NewFieldName:="Start", Width:=15, ShowInMenu:=False, DateFormat:=pjDate_mm_dd_yy, ColumnPosition:=4
+    curproj.Application.TableEditEx Name:="*ClearPlan Driving Path Table", TaskTable:=True, NewFieldName:="Finish", Width:=15, ShowInMenu:=False, DateFormat:=pjDate_mm_dd_yy, ColumnPosition:=5
+    curproj.Application.TableEditEx Name:="*ClearPlan Driving Path Table", TaskTable:=True, NewFieldName:="Total Slack", Width:=10, ShowInMenu:=False, DateFormat:=pjDate_mm_dd_yy, ColumnPosition:=6
 
     'Create CP Driving Path Filter
-    curproj.Application.FilterEdit Name:="*ClearPlan Driving Path Filter", taskfilter:=True, Create:=True, OverwriteExisting:=True, FieldName:=GroupField, Test:="is greater than", Value:="0", ShowInMenu:=False, showsummarytasks:=False
+    curproj.Application.FilterEdit Name:="*ClearPlan Driving Path Filter", TaskFilter:=True, Create:=True, OverwriteExisting:=True, FieldName:=GroupField, test:="is greater than", Value:="0", ShowInMenu:=False, ShowSummaryTasks:=False
     
     'On Error Resume Next
     
@@ -930,4 +926,3 @@ Public Function ExistsInCollection(ByVal col As Collection, ByVal key As Variant
 err: 'If error encountered, item does not exist - return "False" boolean vlaue
     ExistsInCollection = False
 End Function
-


### PR DESCRIPTION
Primary purpose is to consider eDay duration in the TrueFloat calculation. Previous versions only calculated eDays as part of Leads/Lags (by passing units to DateAdd method). This version will use DateDiff to retrun raw difference in minutes between adjust pred/succ dates if eDays are used. Results in accurate path parsing with drivers that have the same end date but different duration units.

...additional commits are result of GitGoof